### PR TITLE
Fix nightly version name

### DIFF
--- a/oneware-extension.json
+++ b/oneware-extension.json
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "version": "0.10.5",
+      "version": "0.10.6",
       "minStudioVersion": "0.21.1.0",
       "targets": [
         {

--- a/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
+++ b/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
@@ -136,7 +136,7 @@ public class GhdlExtensionModule : IModule
             },
             new PackageVersion()
             {
-                Version = "5.0.0-dev",
+                Version = "5.0.0",
                 Targets =
                 [
                     new PackageTarget()

--- a/src/OneWare.GhdlExtension/OneWare.GhdlExtension.csproj
+++ b/src/OneWare.GhdlExtension/OneWare.GhdlExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <Version>0.10.5</Version>
+        <Version>0.10.6</Version>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
The recent addition of the nightly GHDL version has lead to the plugin being displayed as "Unavailable". This is because Version.TryParse() cannot parse the version "5.0.0-dev". This PR changes the version to just "5.0.0" and removes the broken plugin from oneware-extension.json