### PR TITLE
Fix windows ghdl autopath

### DIFF
--- a/oneware-extension.json
+++ b/oneware-extension.json
@@ -57,6 +57,15 @@
           "target": "all"
         }
       ]
+    },
+    {
+      "version": "0.10.7",
+      "minStudioVersion": "0.21.1.0",
+      "targets": [
+        {
+          "target": "all"
+        }
+      ]
     }
   ]
 }

--- a/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
+++ b/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
@@ -147,7 +147,7 @@ public class GhdlExtensionModule : IModule
                         [
                             new PackageAutoSetting()
                             {
-                                RelativePath = "GHDL/bin/ghdl.exe",
+                                RelativePath = "bin/ghdl.exe",
                                 SettingKey = GhdlPathSetting
                             }
                         ]

--- a/src/OneWare.GhdlExtension/OneWare.GhdlExtension.csproj
+++ b/src/OneWare.GhdlExtension/OneWare.GhdlExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <Version>0.10.6</Version>
+        <Version>0.10.7</Version>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
The structure of the zip files containing the binaries of the development builds of GHDL 5.0.0 has changed for the windows platform. This PR sets the correct RealtivePath property