### PR TITLE
Fix autopath on OSX and Linux

### DIFF
--- a/oneware-extension.json
+++ b/oneware-extension.json
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "version": "0.10.7",
+      "version": "0.10.8",
       "minStudioVersion": "0.21.1.0",
       "targets": [
         {

--- a/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
+++ b/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
@@ -160,7 +160,7 @@ public class GhdlExtensionModule : IModule
                         [
                             new PackageAutoSetting()
                             {
-                                RelativePath = "bin/ghdl",
+                                RelativePath = "ghdl-mcode-5.0.1-ubuntu24.04-x86_64/bin/ghdl",
                                 SettingKey = GhdlPathSetting
                             }
                         ]
@@ -173,7 +173,7 @@ public class GhdlExtensionModule : IModule
                         [
                             new PackageAutoSetting()
                             {
-                                RelativePath = "bin/ghdl",
+                                RelativePath = "ghdl-mcode-5.0.1-macos13-x86_64/bin/ghdl",
                                 SettingKey = GhdlPathSetting
                             }
                         ]

--- a/src/OneWare.GhdlExtension/OneWare.GhdlExtension.csproj
+++ b/src/OneWare.GhdlExtension/OneWare.GhdlExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <Version>0.10.7</Version>
+        <Version>0.10.8</Version>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
The new GHDL v5.0.1 release has also changed the internal structure of the OSX and Linux archives. This PR fixes the relevant settings to ensure a smooth user experience