### PR TITLE
Implement functionality supporting VHDL libraries for simulation and synthesis

### DIFF
--- a/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
+++ b/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
@@ -347,7 +347,7 @@ public class GhdlExtensionModule : IModule
                 
                 models.Add(new MenuItemViewModel("GHDL_Folder_Add")
                 {
-                    Header = "Add folder to library",
+                    Header = "Add files in folder to library",
                     Items = items
                 });
             }

--- a/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
+++ b/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
@@ -372,7 +372,7 @@ public class GhdlExtensionModule : IModule
 
     private async Task AddFileToLibraryAsync(string library, IProjectFile file)
     {
-        if (file.Root is UniversalFpgaProjectRoot root)
+        if (file.Root is UniversalFpgaProjectRoot root && !root.CompileExcluded.Contains(file))
         {
             // Prefix library collections with "GHDL-LIB" to reduce chance of collisions with other keys
             root.AddToProjectPropertyArray($"GHDL-LIB_{library}", file.RelativePath);

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -153,13 +153,21 @@ public class GhdlService
         var workingDirectory = file.Root!.FullPath;
         var buildDirectory = Path.Combine(workingDirectory, "build");
         
-        // Remove pre-existing *.cf files from build directory
-        foreach (string configFile in Directory.EnumerateFiles(buildDirectory)
-                     .Where(x => Path.GetExtension(x) is ".cf"))
+        // Ensure existence of build directory
+        if (!Directory.Exists(buildDirectory))
         {
-            File.Delete(configFile);
+            Directory.CreateDirectory(buildDirectory);
         }
-            
+        else
+        {
+            // Remove pre-existing *.cf files from build directory
+            foreach (string configFile in Directory.EnumerateFiles(buildDirectory)
+                         .Where(x => Path.GetExtension(x) is ".cf"))
+            {
+                File.Delete(configFile);
+            }
+        }
+
         List<string> ghdlOptions = [];
         
         ghdlOptions.Add($"--workdir={buildDirectory}");

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -148,8 +148,11 @@ public class GhdlService
             
         List<string> ghdlOptions = [];
         
-        var vhdlStandard = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard));
-        if(vhdlStandard != null) ghdlOptions.Add($"--std={vhdlStandard}");
+        var vhdlStandard = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard)) ?? root.GetProjectProperty("VHDL_Standard");
+        if (vhdlStandard != null)
+        {
+            ghdlOptions.Add($"--std={vhdlStandard}");
+        }
     
         var additionalGhdlOptions = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.AdditionalGhdlOptions));
         if(additionalGhdlOptions != null) ghdlOptions.AddRange(additionalGhdlOptions.Split(' '));
@@ -229,7 +232,7 @@ public class GhdlService
         
         List<string> ghdlOptions = [];
         
-        var vhdlStandard = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard));
+        var vhdlStandard = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard)) ?? root.GetProjectProperty("VHDL_Standard");
         if(vhdlStandard != null) ghdlOptions.Add($"--std={vhdlStandard}");
     
         var additionalGhdlOptions = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.AdditionalGhdlOptions));
@@ -262,7 +265,7 @@ public class GhdlService
         
         List<string> ghdlOptions = [];
         
-        var vhdlStandard = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard));
+        var vhdlStandard = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard)) ?? root.GetProjectProperty("VHDL_Standard");
         if(vhdlStandard != null) ghdlOptions.Add($"--std={vhdlStandard}");
     
         var additionalGhdlOptions = context.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.AdditionalGhdlOptions));
@@ -357,7 +360,7 @@ public class GhdlService
             var top = Path.GetFileNameWithoutExtension(file.FullPath);
             var workingDirectory = root.FullPath;
 
-            var vhdlStandard = root.GetProjectProperty("VHDL_Standard") ?? "02";
+            var vhdlStandard = root.GetProjectProperty("VHDL_Standard") ?? "93c";
             List<string> ghdlOptions = [$"--std={vhdlStandard}"];
 
             var elaborateResult = await ElaborateAsync(file, settings);
@@ -441,7 +444,7 @@ public class GhdlService
                 settings.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.AdditionalGhdlSimOptions));
             if (additionalGhdlSimOptions != null) simulatingOptions.AddRange(additionalGhdlSimOptions.Split(' '));
 
-            var vhdlStandard = settings.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard));
+            var vhdlStandard = root.GetProjectProperty("VHDL_Standard") ?? settings.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.VhdlStandard));
             if (vhdlStandard != null) ghdlOptions.Add($"--std={vhdlStandard}");
 
             var assertLevel = settings.GetBenchProperty(nameof(GhdlSimulatorToolbarViewModel.AssertLevel));

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -224,7 +224,7 @@ public class GhdlService
         IEnumerable<string> vhdlFiles = root.Files
             .Where(x => !root.CompileExcluded.Contains(x))
             .Where(x => x.Extension is ".vhd" or ".vhdl")
-            .Where(x => !libraryFiles.Contains(x.RelativePath))
+            .Where(x => libraryFiles.Contains(x.RelativePath))
             .Select(x => x.RelativePath);
         
         List<string> ghdlOptions = [];

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -158,6 +158,19 @@ public class GhdlService
         ghdlInitArguments.AddRange(ghdlOptions);
         ghdlInitArguments.AddRange(vhdlFiles);
 
+        List<string> ghdlMakeArguments = ["-m"];
+        ghdlMakeArguments.AddRange(ghdlOptions);
+        ghdlMakeArguments.Add($"{GetLibraryPrefixForToplevel(root)}{top}");
+
+        List<string> ghdlElaborateArguments = ["-e"];
+        ghdlElaborateArguments.AddRange(ghdlOptions);
+        ghdlElaborateArguments.Add($"{GetLibraryPrefixForToplevel(root)}{top}");
+
+        var initFiles = await ExecuteGhdlAsync(ghdlInitArguments, workingDirectory,
+            "GHDL Init...",
+            AppState.Loading, true);
+        if (!initFiles.success) return false;
+        
         if (libnames is not null)
         {
             foreach (string libname in libnames)
@@ -171,9 +184,9 @@ public class GhdlService
             }
         }
 
-        List<string> ghdlMakeArguments = ["-m"];
-        ghdlMakeArguments.AddRange(ghdlOptions);
-        ghdlMakeArguments.Add($"{GetLibraryPrefixForToplevel(root)}{top}");
+        var make = await ExecuteGhdlAsync(ghdlMakeArguments, workingDirectory,
+            "Running GHDL Make...", AppState.Loading, true);
+        if (!make.success) return false;
         
         if (libnames is not null)
         {
@@ -187,19 +200,6 @@ public class GhdlService
                 }
             }
         }
-
-        List<string> ghdlElaborateArguments = ["-e"];
-        ghdlElaborateArguments.AddRange(ghdlOptions);
-        ghdlElaborateArguments.Add($"{GetLibraryPrefixForToplevel(root)}{top}");
-
-        var initFiles = await ExecuteGhdlAsync(ghdlInitArguments, workingDirectory,
-            "GHDL Init...",
-            AppState.Loading, true);
-        if (!initFiles.success) return false;
-
-        var make = await ExecuteGhdlAsync(ghdlMakeArguments, workingDirectory,
-            "Running GHDL Make...", AppState.Loading, true);
-        if (!make.success) return false;
 
         var elaboration = await ExecuteGhdlAsync(ghdlElaborateArguments, workingDirectory,
             "Running GHDL Elaboration...", AppState.Loading, true);

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -336,13 +336,10 @@ public class GhdlService
             {
                 continue;
             }
-
-            foreach (var file in libfiles)
+            
+            if (libfiles.Contains(top))
             {
-                if (libfiles.Contains(top))
-                {
-                    return $"{libname}.";
-                }
+                return $"{libname}.";
             }
         }
         

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -427,6 +427,8 @@ public class GhdlService
                 "FST" => "fst",
                 _ => string.Empty
             };
+            
+            await AddSimFileExtensionToIncludesAsync(root, waveOutput);
 
             var waveFilePath = Path.Combine(file.TopFolder!.RelativePath, $"{top}.{waveOutput.ToLower()}");
             var waveFormFileArgument = $"--{waveOutputArgument}={waveFilePath}";
@@ -489,5 +491,37 @@ public class GhdlService
         }
 
         return false;
+    }
+
+    private async Task AddSimFileExtensionToIncludesAsync(UniversalFpgaProjectRoot root, string extension)
+    {
+        string actualExtension = extension switch
+        {
+            "VCD" => "vcd",
+            "GHW" => "ghw",
+            "FST" => "fst",
+            _ => string.Empty
+        };
+
+        if (actualExtension == string.Empty)
+        {
+            return;
+        }
+
+        var includedFileTypes = root.GetProjectPropertyArray("Include");
+
+        if (includedFileTypes is null)
+        {
+            return;
+        }
+
+        if (includedFileTypes.Contains($"*.{actualExtension}"))
+        {
+            return;
+        }
+        
+        root.AddToProjectPropertyArray("Include", $"*.{actualExtension}");
+
+        await _projectExplorerService.SaveProjectAsync(root);
     }
 }

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -402,6 +402,12 @@ public class GhdlService
     {
         if (file.Root is UniversalFpgaProjectRoot root)
         {
+            foreach (string configFile in Directory.EnumerateFiles(root.FullPath)
+                         .Where(x => Path.GetExtension(x) is ".cf"))
+            {
+                File.Delete(configFile);
+            }
+            
             _dockService.Show<IOutputService>();
 
             var settings = await TestBenchContextManager.LoadContextAsync(file);

--- a/src/OneWare.GhdlExtension/ViewModels/GhdlSimulatorToolbarViewModel.cs
+++ b/src/OneWare.GhdlExtension/ViewModels/GhdlSimulatorToolbarViewModel.cs
@@ -1,6 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using OneWare.Essentials.Models;
 using OneWare.UniversalFpgaProjectSystem.Context;
+using OneWare.UniversalFpgaProjectSystem.Models;
 using OneWare.UniversalFpgaProjectSystem.Services;
+using ReactiveUI;
 
 namespace OneWare.GhdlExtension.ViewModels;
 
@@ -20,9 +23,22 @@ public class GhdlSimulatorToolbarViewModel(TestBenchContext context, IFpgaSimula
     public string[] AvailableVhdlStandards => ["87", "93", "93c", "00", "02", "08", "19"];
     public string VhdlStandard
     {
-        get => context.GetBenchProperty(nameof(VhdlStandard)) ?? "93c";
+        get {
+            if (context.File is IProjectFile testbenchfile && testbenchfile.Root is UniversalFpgaProjectRoot root)
+            {
+                
+                return root.GetProjectProperty("VHDL_Standard") ?? context.GetBenchProperty(nameof(VhdlStandard)) ?? "93c";
+            }
+            
+            return context.GetBenchProperty(nameof(VhdlStandard)) ?? "93c";
+        }
         set
         {
+            if (context.File is IProjectFile testbenchfile && testbenchfile.Root is UniversalFpgaProjectRoot root)
+            {
+                root.SetProjectProperty("VHDL_Standard", value);
+            }
+            
             context.SetBenchProperty(nameof(VhdlStandard), value);
             OnPropertyChanged();
         }


### PR DESCRIPTION
# What does this PR implement?

This PR adds several new options to describe which files are part of which library and which libraries exist in the first place. The setting for the available libraries has been implemented using the ProjectSettingsService.

![image](https://github.com/user-attachments/assets/0572fb56-dceb-4429-b02e-f80521f79e74)

Additionally, the right-click menu has been expanded with options to add a file to or remove a file from a given library.
![image](https://github.com/user-attachments/assets/34b4b5d7-13ea-47e4-abeb-4e5fb396a6c7)
![image](https://github.com/user-attachments/assets/c085d4cf-1b13-464f-9e09-029725a8abfb)

For bulk additions, the option to add all files contained in a folder to a single library is also available.
![image](https://github.com/user-attachments/assets/b2b73fa3-2116-4e3c-a0b9-1b57b06f70be)

Additionally, the VHDL standard of the Simulation Toolbar has been coupled to the projects VHDL standard setting, the output of ExecuteGhdlAsync() has been split into stdout and stderr so as to not include assert outputs in generated files saved via File.WriteAllTextAsync(). For Verilog conversion the -o option is used for GHDL 5.0.1 and newer. This allows GHDL to write to the output file directly, significantly speeding up the conversion of large designs. Another new feature is that the filetype of the simulation output file is added to the included files if it has not been added already.

The executed GHDL commands have been expanded to use the library options to correctly compile designs containing any number of libraries. The GHDL build directory (where GHDL emits its object files) has been changed to the projects' build directory.

# Testing

I have tested these changes on Windows, with designs containing both zero, three and four (of which one was empty) libraries. I have tested the Verilog generation with GHDL 4.1.0 and 5.0.1. I have tested both simulation and conversion to Verilog and Dot-Netlists. Since my changes do not contain Windows-Specific code, they should also work on all other platforms that are supported by OneWare Studio.

# Notes

To prevent the file access violations fixed in https://github.com/one-ware/OneWare/pull/61 in the current version of OneWare Studio, I have also used the Avalonia UIThread.

Merging #9 (this requires a new release of the GHDL extension) would also enable users on OS X and Linux to easily take advantage of the faster VHDL -> Verilog conversion times offered by GHDL 5.0.1.

This PR implements the features requested in #2.