### PR TITLE
Use '/' instead of '\' as path separator

### DIFF
--- a/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
+++ b/src/OneWare.GhdlExtension/GhdlExtensionModule.cs
@@ -287,7 +287,7 @@ public class GhdlExtensionModule : IModule
                         continue;
                     }
 
-                    if (libfiles.Contains(file.RelativePath))
+                    if (libfiles.Contains(file.RelativePath.Replace('\\', '/')))
                     {
                         associatedLibrary = libname;
                         break;
@@ -376,7 +376,7 @@ public class GhdlExtensionModule : IModule
         if (file.Root is UniversalFpgaProjectRoot root && !root.CompileExcluded.Contains(file) && !(root.GetProjectPropertyArray($"GHDL-LIB_{library}") ?? Array.Empty<string>()).Any(x => x.Equals(file.RelativePath)))
         {
             // Prefix library collections with "GHDL-LIB" to reduce chance of collisions with other keys
-            root.AddToProjectPropertyArray($"GHDL-LIB_{library}", file.RelativePath);
+            root.AddToProjectPropertyArray($"GHDL-LIB_{library}", file.RelativePath.Replace('\\', '/'));
 
             // Save project so that the modifications are stored to disk
             // Use the UI Thread to prevent file access violations
@@ -389,7 +389,7 @@ public class GhdlExtensionModule : IModule
         if (file.Root is UniversalFpgaProjectRoot root)
         {
             root.SetProjectPropertyArray($"GHDL-LIB_{library}",
-                root.GetProjectPropertyArray($"GHDL-LIB_{library}")!.Where(x => !x.Equals(file.RelativePath))
+                root.GetProjectPropertyArray($"GHDL-LIB_{library}")!.Where(x => !x.Equals(file.RelativePath.Replace('\\', '/')))
                     .ToArray());
             
             // Save project so that the modifications are stored to disk

--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -254,7 +254,7 @@ public class GhdlService
         IEnumerable<string> vhdlFiles = root.Files
             .Where(x => !root.CompileExcluded.Contains(x))
             .Where(x => x.Extension is ".vhd" or ".vhdl")
-            .Where(x => libraryFiles.Contains(x.RelativePath))
+            .Where(x => libraryFiles.Contains(x.RelativePath.Replace('\\', '/')))
             .Select(x => x.RelativePath);
         
         ghdlOptions.Add($"--work={libname}");


### PR DESCRIPTION
If a project uses VHDL libraries and the library associations are created under Windows, they are not recognized under Linux and vice versa due to the different separators used by these platforms. This PR explicitly uses the forward slash as a path separator for all operating systems, thereby improving cross-platform compatibility