### PR TITLE
Prevent duplicate usages of the --work argument in ghdl calls

### DIFF
--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -257,10 +257,9 @@ public class GhdlService
             .Where(x => libraryFiles.Contains(x.RelativePath))
             .Select(x => x.RelativePath);
         
-        ghdlOptions.Add($"--work={libname}");
-        
         List<string> ghdlInitArguments = ["-i"];
         ghdlInitArguments.AddRange(ghdlOptions);
+        ghdlInitArguments.Add($"--work={libname}");
         ghdlInitArguments.AddRange(vhdlFiles);
         
         var initFiles = await ExecuteGhdlAsync(ghdlInitArguments, workingDirectory,
@@ -284,10 +283,9 @@ public class GhdlService
             return false;
         }
         
-        ghdlOptions.Add($"--work={libname}");
-        
         List<string> ghdlMakeArguments = ["-m"];
         ghdlMakeArguments.AddRange(ghdlOptions);
+        ghdlMakeArguments.Add($"--work={libname}");
         ghdlMakeArguments.Add($"{GetLibraryPrefixForToplevel(root)}{top}");
         
         var make = await ExecuteGhdlAsync(ghdlMakeArguments, workingDirectory,


### PR DESCRIPTION
Currently, the --work argument of GHDL is defined for every library and previous definitions are not removed. This PR fixes this issue