### PR TITLE
Fix error messages during library analysis

### DIFF
--- a/src/OneWare.GhdlExtension/Services/GhdlService.cs
+++ b/src/OneWare.GhdlExtension/Services/GhdlService.cs
@@ -299,7 +299,7 @@ public class GhdlService
             return false;
         }
 
-        string top = Path.Combine(root.RootFolderPath, root.TopEntity);
+        string top = Path.GetFileNameWithoutExtension(root.TopEntity);
 
         List<string> ghdlMakeArguments = ["-m"];
         ghdlMakeArguments.AddRange(ghdlOptions);
@@ -358,7 +358,7 @@ public class GhdlService
             return "";
         }
 
-        string top = Path.Combine(root.RootFolderPath, root.TopEntity);
+        string top = root.TopEntity;
 
         foreach (string libname in libnames)
         {


### PR DESCRIPTION
The switch to unix paths by default with OWS 1.0 lead to some issues with regards to determining the correct library the toplevel entity belongs to. While this results in a GHDL error message, synthesis does not seem to be affected, since valid output is still generated. This PR fixes these issues and has been tested on a design containing three different libraries apart from the default `work` library